### PR TITLE
02 Plano de fundo

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lojinha_alura/pages/detalhes.dart';
 
 import 'inicio.dart';
+import 'model/movel.dart';
 import 'pages/carrinho.dart';
 import 'util/app_route.dart';
 
@@ -21,7 +22,16 @@ class MyApp extends StatelessWidget {
       routes: {
         AppRoute.inicio: (context) => Inicio(),
         AppRoute.carrinho: (context) => const Carrinho(),
-        AppRoute.detalhes: (context) => const Detalhes(),
+      },
+      onGenerateRoute: (settings) {
+        if (settings.name == AppRoute.detalhes) {
+          final arguments = settings.arguments as Movel;
+          return MaterialPageRoute(
+            builder: (context) => Detalhes(
+              movel: arguments,
+            ),
+          );
+        }
       },
     );
   }

--- a/lib/pages/detalhes.dart
+++ b/lib/pages/detalhes.dart
@@ -1,20 +1,33 @@
 import 'package:flutter/material.dart';
-import 'package:lojinha_alura/util/app_route.dart';
+
+import '/model/movel.dart';
+import '/util/app_route.dart';
+import '/widgets/appbar_custom.dart';
 
 class Detalhes extends StatelessWidget {
-  const Detalhes({Key? key}) : super(key: key);
+  final Movel movel;
+  const Detalhes({Key? key, required this.movel}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Detalhes'),
+    return Container(
+      decoration: BoxDecoration(
+        image: DecorationImage(
+          image: AssetImage('lib/assets/imagens/${movel.foto}'),
+          fit: BoxFit.cover,
+        ),
       ),
-      body: ElevatedButton(
-        onPressed: () {
-          Navigator.pushNamed(context, AppRoute.carrinho);
-        },
-        child: const Text('Agora para a pagina carrinho'),
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: AppBarCustom(
+          titulo: '${movel.titulo}',
+        ),
+        body: ElevatedButton(
+          onPressed: () {
+            Navigator.pushNamed(context, AppRoute.carrinho);
+          },
+          child: const Text('Agora para a pagina carrinho'),
+        ),
       ),
     );
   }

--- a/lib/widgets/elemento_grid_produtos.dart
+++ b/lib/widgets/elemento_grid_produtos.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lojinha_alura/util/app_route.dart';
 import 'package:lojinha_alura/widgets/degrade_elemento_grid_produtos.dart';
 import 'package:lojinha_alura/widgets/imagem_elemento_grid_produto.dart';
 import 'package:lojinha_alura/widgets/titulo_elemento_grid_produtos.dart';
@@ -11,24 +12,29 @@ class ElementoGridProdutos extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(boxShadow: [
-        BoxShadow(
-          spreadRadius: 2,
-          blurRadius: 8,
-          color: Colors.black12,
-        )
-      ]),
-      margin: EdgeInsets.all(10),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(8),
-        child: Stack(
-          alignment: Alignment.center,
-          children: [
-            ImagemElementoGridProdutos(imagem: movel.foto),
-            DegradeElementoGridProdutos(),
-            TituloElementoGridProdutos(titulo: movel.titulo),
-          ],
+    return InkWell(
+      onTap: () {
+        Navigator.pushNamed(context, AppRoute.detalhes, arguments: movel);
+      },
+      child: Container(
+        decoration: BoxDecoration(boxShadow: [
+          BoxShadow(
+            spreadRadius: 2,
+            blurRadius: 8,
+            color: Colors.black12,
+          )
+        ]),
+        margin: EdgeInsets.all(10),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              ImagemElementoGridProdutos(imagem: movel.foto),
+              DegradeElementoGridProdutos(),
+              TituloElementoGridProdutos(titulo: movel.titulo),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
**Pagina de Detalhes com plano de fundo.**

- Valores recebidos pro argumentos pelo Navigator.pushNamed.
- Utilização do onGenerateRoute para passagem de parâmetro para rota.
- Uso do Widget Container para definir movel.foto como plano de fundo.
- Scaffold recebendo a propriedade backgroundColor: Colors.transparent para tornar visível a imagem de fundo do Container 